### PR TITLE
add method to use callbacks in json_fields

### DIFF
--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -175,28 +175,28 @@ export default {
 			}
 			return keys
 		},
-        callItemCallback: function(field, itemValue) {
-            if (typeof field === 'object' && typeof field.callback === 'function') {
-                return field.callback(itemValue);
-            }
+		callItemCallback: function(field, itemValue) {
+			if (typeof field === 'object' && typeof field.callback === 'function') {
+				return field.callback(itemValue);
+			}
 
-            return itemValue;
-        },
-        getNestedData: function(key, item) {
-            const field = (typeof key === 'object') ? key.field : key;
+			return itemValue;
+		},
+		getNestedData: function(key, item) {
+			const field = (typeof key === 'object') ? key.field : key;
 
-            let valueFromNestedKey = null
-            let keyNestedSplit = field.split(".")
+			let valueFromNestedKey = null
+			let keyNestedSplit = field.split(".")
 
-            valueFromNestedKey = item[keyNestedSplit[0]]
-            for (let j = 1; j < keyNestedSplit.length; j++) {
-                valueFromNestedKey = valueFromNestedKey[keyNestedSplit[j]]
-            }
+			valueFromNestedKey = item[keyNestedSplit[0]]
+			for (let j = 1; j < keyNestedSplit.length; j++) {
+				valueFromNestedKey = valueFromNestedKey[keyNestedSplit[j]]
+			}
 
-            valueFromNestedKey = this.callItemCallback(key, valueFromNestedKey);
+			valueFromNestedKey = this.callItemCallback(key, valueFromNestedKey);
 
-            return valueFromNestedKey;
-        },
+			return valueFromNestedKey;
+		},
 		base64ToBlob: function (data, mime) {
 			let base64 = window.btoa(window.unescape(encodeURIComponent(data)))
 			let bstr   = atob(base64)

--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -162,15 +162,28 @@ export default {
 			}
 			return keys
 		},
-		getNestedData: function(key, item) {
-			let valueFromNestedKey = null
-			let keyNestedSplit = key.split(".")
-			valueFromNestedKey = item[keyNestedSplit[0]]
-			for (let j = 1; j < keyNestedSplit.length; j++) {
-				valueFromNestedKey = valueFromNestedKey[keyNestedSplit[j]]
-			}
-			return valueFromNestedKey;
-		},
+        callItemCallback: function(field, itemValue) {
+            if (typeof field === 'object' && typeof field.callback === 'function') {
+                return field.callback(itemValue);
+            }
+
+            return itemValue;
+        },
+        getNestedData: function(key, item) {
+            const field = (typeof key === 'object') ? key.field : key;
+
+            let valueFromNestedKey = null
+            let keyNestedSplit = field.split(".")
+
+            valueFromNestedKey = item[keyNestedSplit[0]]
+            for (let j = 1; j < keyNestedSplit.length; j++) {
+                valueFromNestedKey = valueFromNestedKey[keyNestedSplit[j]]
+            }
+
+            valueFromNestedKey = this.callItemCallback(key, valueFromNestedKey);
+
+            return valueFromNestedKey;
+        },
 		base64ToBlob: function (data, mime) {
 			let base64 = window.btoa(window.unescape(encodeURIComponent(data)))
 			let bstr   = atob(base64)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ const app = new Vue({
         json_fields: {
             'Complete name': 'name',
             'City': 'city',
-            'Telephone': 'phone.landline',
+            'Telephone': 'phone.mobile',
+            'Telephone 2' : {
+                field: 'phone.landline',
+                callback: (value) => {
+                    return `Landline Phone - ${value}`;
+                }
+            },
         },
         json_data: [
             {
@@ -79,8 +85,21 @@ In your HTML call it like
 REQUIRED
 - json_data: Contains the data you want to export,
 - json_fields: You can select what fields to export, especify nested data and assign labels to the fields
-the key is the label, the value is the JSON field.
-
+the key is the label, the value is the JSON field. This will export the field data 'as is'.
+    If you need to customize the the exported data you can define a callback function. Thanks to @gucastiliao.
+```js
+let json_fields = {
+    // regular field (exported data 'as is')
+    fieldLabel: attributeName, // nested attribute supported
+    // callback function for data formatting
+    anotherFieldLabel: {
+        field: anotherAttributeName, // nested attribute supported
+        callback: (value) => {
+            return `formatted value ${value}`
+        }
+    },
+}
+```
 OPTIONAL
 - type: xls o csv, xls is the default value.
 - name: filename of the document you donwload.


### PR DESCRIPTION
Hello! I was using the lib and it became necessary to modify the data before sending to excel, then I added a method for use of callbacks in json_fields.

If a field need callback, he need to be a object with 2 attributes: 
`field` that is the name of field in `json_data` 
`callback` which receive a function for use with value from `json_data`

Usage example:

```js
json_fields : {
    "Complete name" : "name",
    "City" : "city",
    "Telephone" : {
        field: "phone.landline",
        callback: (value) => {
            return `Landline Phone - ${value}`;
        }
    },
}
```

I believe it is a great option for everyone who also needs to modify the data to send to excel