### PR TITLE
Fields prop is required and it shouldn't

### DIFF
--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -26,8 +26,7 @@ export default {
 		// fields inside the Json Object that you want to export
 		// if no given, all the properties in the Json are exported
 		'fields':{
-			type: Object,
-			required: true
+			type: Object
 		},
 		// Title for the data
 		'title':{


### PR DESCRIPTION
Required was deleted from fields prop, because in getKeys method it is checked if fields is true. 