### PR TITLE
Improve massive csv file download

### DIFF
--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -130,17 +130,18 @@ export default {
 		Transform json data into an CSV file.
 		*/
 		jsonToCSV (data) {
-			var csvData = ''
+			var csvData = [];
 			//Header
 			if( this.title != null ){
-				csvData += this.parseExtraData(this.title, '${data}\r\n')
+				csvData.push(this.parseExtraData(this.title, '${data}\r\n'));
 			}
 			//Fields
 			for (let key in data[0]) {
-				csvData +=  key + ','
+				csvData.push(key);
+				csvData.push(',');
 			}
-			csvData = csvData.slice(0, csvData.length - 1)
-			csvData += '\r\n'
+			csvData.pop();
+			csvData.push('\r\n');
 			//Data
 			data.map(function (item) {
 				for (let key in item) {
@@ -148,16 +149,17 @@ export default {
 					if (escapedCSV.match(/[,"\n]/)) {
 						escapedCSV = '"' + escapedCSV.replace(/\"/g, "\"\"") + '"'
 					}
-					csvData += escapedCSV + ','
+					csvData.push(escapedCSV); 
+					csvData.push(',');
 				}
-				csvData = csvData.slice(0, csvData.length - 1)
-				csvData += '\r\n'
+				csvData.pop();
+				csvData.push('\r\n');
 			})
 			//Footer
 			if( this.footer != null ){
-				csvData += this.parseExtraData(this.footer, '${data}\r\n')
+				csvData.push(this.parseExtraData(this.footer, '${data}\r\n'));
 			}
-			return csvData
+			return csvData.join('');
 		},
 		/*
 		getProcessedJson


### PR DESCRIPTION
Hello, 
I am currently using this module in my project. I have found that there is a serious performance penalty when I download a large csv file.

Its csv download performance is very low due to String.slice in jsonToCSV. Time complexity can be improved from N squared to N by using Array.pop instead of String.slice. The improved code shows overwhelming performance when downloading massive CSV files with dozens of columns.

For a 10 column, 20,000-line file, the original code takes about 9 seconds and the improved code takes just tens of **milli**seconds. The larger the file size, the wider the gap.