### PR TITLE
Improve data loss problem

### DIFF
--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -187,7 +187,7 @@ export default {
       //Data
       data.map(function(item) {
         for (let key in item) {
-          let escapedCSV = item[key] + ""; // cast Numbers to string
+          let escapedCSV = '=\"' + item[key] + '\"'; // cast Numbers to string
           if (escapedCSV.match(/[,"\n]/)) {
             escapedCSV = '"' + escapedCSV.replace(/\"/g, '""') + '"';
           }


### PR DESCRIPTION
Hello,
I found that csv file download has a problem.
In the case of a very large number, the numbers do not appear correctly in the csv file as shown below.

20180417134115360727   => 2.01804E+19 (data loss, this number represents 20180411104740000000)

To fix this problem, I modified just one line.
thank you.

