### PR TITLE
Per columns headers

### DIFF
--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -43,7 +43,7 @@ export default {
       default: null,
     },
 
-    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    // Title(s) for single column data, must be an array (ex: ['titleCol0',,TitleCol2])
     perColumnsHeaders:  {
       default: null,
     },

--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -42,6 +42,12 @@ export default {
     header: {
       default: null,
     },
+
+    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    perColumnsHeaders:  {
+      default: null,
+    },
+
     // Footer(s) for the data, could be a string or an array of strings (multiple footers)
     footer: {
       default: null,
@@ -158,6 +164,16 @@ export default {
         );
       }
 
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          xlsData += "<tr>";
+          for (let pchKey in perColumnsHeaders) {
+              xlsData += "<th>" + perColumnsHeaders[pchKey] + "</th>";
+          }
+          xlsData += "</tr>";
+      }
+
       //Fields
       xlsData += "<tr>";
       for (let key in data[0]) {
@@ -209,6 +225,17 @@ export default {
       const header = this.header || this.$attrs.title;
       if (header) {
         csvData.push(this.parseExtraData(header, "${data}\r\n"));
+      }
+
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          for (let pchKey in perColumnsHeaders) {
+              csvData.push(perColumnsHeaders[pchKey]);
+              csvData.push(",");
+          }
+          csvData.pop();
+          csvData.push("\r\n");
       }
 
       //Fields

--- a/dist/vue-json-excel.cjs.js
+++ b/dist/vue-json-excel.cjs.js
@@ -207,7 +207,7 @@ var script = {
     header: {
       default: null,
     },
-    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    // Title(s) for single column data, must be an array (ex: ['titleCol0',,TitleCol2])
     perColumnsHeaders:  {
       default: null,
     },

--- a/dist/vue-json-excel.cjs.js
+++ b/dist/vue-json-excel.cjs.js
@@ -207,6 +207,10 @@ var script = {
     header: {
       default: null,
     },
+    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    perColumnsHeaders:  {
+      default: null,
+    },
     // Footer(s) for the data, could be a string or an array of strings (multiple footers)
     footer: {
       default: null,
@@ -323,6 +327,16 @@ var script = {
         );
       }
 
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          xlsData += "<tr>";
+          for (let pchKey in perColumnsHeaders) {
+              xlsData += "<th>" + perColumnsHeaders[pchKey] + "</th>";
+          }
+          xlsData += "</tr>";
+      }
+
       //Fields
       xlsData += "<tr>";
       for (let key in data[0]) {
@@ -374,6 +388,17 @@ var script = {
       const header = this.header || this.$attrs.title;
       if (header) {
         csvData.push(this.parseExtraData(header, "${data}\r\n"));
+      }
+
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          for (let pchKey in perColumnsHeaders) {
+              csvData.push(perColumnsHeaders[pchKey]);
+              csvData.push(",");
+          }
+          csvData.pop();
+          csvData.push("\r\n");
       }
 
       //Fields

--- a/dist/vue-json-excel.esm.js
+++ b/dist/vue-json-excel.esm.js
@@ -205,7 +205,7 @@ var script = {
     header: {
       default: null,
     },
-    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    // Title(s) for single column data, must be an array (ex: ['titleCol0',,TitleCol2])
     perColumnsHeaders:  {
       default: null,
     },

--- a/dist/vue-json-excel.esm.js
+++ b/dist/vue-json-excel.esm.js
@@ -205,6 +205,10 @@ var script = {
     header: {
       default: null,
     },
+    // Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+    perColumnsHeaders:  {
+      default: null,
+    },
     // Footer(s) for the data, could be a string or an array of strings (multiple footers)
     footer: {
       default: null,
@@ -321,6 +325,16 @@ var script = {
         );
       }
 
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          xlsData += "<tr>";
+          for (let pchKey in perColumnsHeaders) {
+              xlsData += "<th>" + perColumnsHeaders[pchKey] + "</th>";
+          }
+          xlsData += "</tr>";
+      }
+
       //Fields
       xlsData += "<tr>";
       for (let key in data[0]) {
@@ -372,6 +386,17 @@ var script = {
       const header = this.header || this.$attrs.title;
       if (header) {
         csvData.push(this.parseExtraData(header, "${data}\r\n"));
+      }
+
+      // perColumnsHeaders
+      const perColumnsHeaders = this.perColumnsHeaders;
+      if(Array.isArray(perColumnsHeaders)) {
+          for (let pchKey in perColumnsHeaders) {
+              csvData.push(perColumnsHeaders[pchKey]);
+              csvData.push(",");
+          }
+          csvData.pop();
+          csvData.push("\r\n");
       }
 
       //Fields

--- a/dist/vue-json-excel.umd.js
+++ b/dist/vue-json-excel.umd.js
@@ -211,7 +211,7 @@
 	    header: {
 	      default: null,
 		},
-		// Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+		// Title(s) for single column data, must be an array (ex: ['titleCol0',,TitleCol2])
 		perColumnsHeaders:  {
 			default: null,
 		  },

--- a/dist/vue-json-excel.umd.js
+++ b/dist/vue-json-excel.umd.js
@@ -210,7 +210,11 @@
 	    // Title(s) for the data, could be a string or an array of strings (multiple titles)
 	    header: {
 	      default: null,
-	    },
+		},
+		// Title(s) for single column data, must be an array where key is the index of columns (ex: ['titleCol0',,TitleCol2])
+		perColumnsHeaders:  {
+			default: null,
+		  },
 	    // Footer(s) for the data, could be a string or an array of strings (multiple footers)
 	    footer: {
 	      default: null,
@@ -325,7 +329,17 @@
 	          header,
 	          '<tr><th colspan="' + colspan + '">${data}</th></tr>'
 	        );
-	      }
+		  }
+		  
+		  // perColumnsHeaders
+		  const perColumnsHeaders = this.perColumnsHeaders;
+		  if(Array.isArray(perColumnsHeaders)) {
+			  xlsData += "<tr>";
+			  for (let pchKey in perColumnsHeaders) {
+				  xlsData += "<th>" + perColumnsHeaders[pchKey] + "</th>";
+			  }
+			  xlsData += "</tr>";
+		  }
 
 	      //Fields
 	      xlsData += "<tr>";
@@ -378,7 +392,18 @@
 	      const header = this.header || this.$attrs.title;
 	      if (header) {
 	        csvData.push(this.parseExtraData(header, "${data}\r\n"));
-	      }
+		  }
+		  
+		  // perColumnsHeaders
+		  const perColumnsHeaders = this.perColumnsHeaders;
+		  if(Array.isArray(perColumnsHeaders)) {
+			  for (let pchKey in perColumnsHeaders) {
+				  csvData.push(perColumnsHeaders[pchKey]);
+				  csvData.push(",");
+			  }
+			  csvData.pop();
+			  csvData.push("\r\n");
+		  }
 
 	      //Fields
 	      for (let key in data[0]) {


### PR DESCRIPTION
Hi, for my needs I needed to create extra headers only for some columns. So I created this new feature.

'perColumnsHeaders' is the new property:

Name: perColumnsHeaders,
Type: Array
Description: Title(s) for single column data (ex: ['titleCol0',,TitleCol2,,TitleCol4])
Default: null