### PR TITLE
bugfix: beforeFinish never ended if data is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 npm-debug.log
 node_modules
 package-lock.json
+
+.history

--- a/JsonExcel.vue
+++ b/JsonExcel.vue
@@ -103,6 +103,7 @@ export default {
       if (typeof this.fetch === "function" || !data) data = await this.fetch();
 
       if (!data || !data.length) {
+        if (typeof this.beforeFinish === "function") await this.beforeFinish();
         return;
       }
 


### PR DESCRIPTION
There's an issue with current implementation of `beforeFinish` prop. If data from `:fetch` is empty (null, etc), then `beforeFinish` would never fire, so your loader/spinner would be on forever. This one fixes this issue.